### PR TITLE
Update dependencies to support Java 9+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+
 lazy val root = project.in(file(".")).
   enablePlugins(ScalaJSPlugin)
 
@@ -9,9 +10,9 @@ version := "0.8"
 
 organization := "org.querki"
 
-scalaVersion := "2.12.0"
+scalaVersion := "2.12.8"
 
-crossScalaVersions := Seq("2.10.5", "2.11.8", "2.12.0")
+crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8")
 
 homepage := Some(url("http://www.querki.net/"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.18

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")

--- a/project/sbt-ui.sbt
+++ b/project/sbt-ui.sbt
@@ -1,3 +1,0 @@
-// This plugin represents functionality that is to be added to sbt in the future
-
-addSbtPlugin("org.scala-sbt" % "sbt-core-next" % "0.1.1")


### PR DESCRIPTION
Also this PR removes https://github.com/sbt/sbt-core-next which seems no longer required.