### PR TITLE
Enable cross-building for Scala.js 0.6 and 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@ The final problem doesn't arise in every situation, but is insuperable when it d
 
 So this isn't a slam-dunk argument either way. `@ScalaJSDefined` easier to set up, and can be used to for interpreting native JS objects as well as creating them, but is either wordier at the call site (if you use the pure version), or requires that you use mutable fields, and you have to be very careful with your signature definitions. And it won't always work for jQuery facades. It's up to you, as the facade designer, to decide whether you prefer that, or the extra design-side boilerplate required by JSOptionBuilder.
 
+### Building
+
+Use the following commands to cross-compile / cross-build for scala `2.12` / `2.13` and scala-js `0.6` / `1.0`:
+
+```bash~~~~
+SCALAJS_VERSION=0.6.32 sbt +publishLocal
+SCALAJS_VERSION=1.0.1 sbt +publishLocal
+```
+
 ### TO DO
 
 Some of the boilerplate involved in using JSOptionBuilder could probably be tamed with a few macros.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Scala.js cross-build support
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.32")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.1")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,18 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
+// Scala.js cross-build support
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.32")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
+
+libraryDependencies ++= {
+  if(scalaJSVersion.startsWith("1.")) {
+    Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0" )
+  } else {
+    Nil
+  }
+}


### PR DESCRIPTION
Could you please publish a Scala.js `0.6` and `1.0` version for Scala `2.12` and `2.13` accordingly?

Hope this is helpful to do it...